### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/smart2000usb/__init__.py
+++ b/custom_components/smart2000usb/__init__.py
@@ -27,9 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN][entry.entry_id] = entry.data
     # Forward the setup to the sensor platform
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "sensor")
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
     _LOGGER.debug("Smart2000USB entry setup completed successfully and update listener registered")
     return True
 


### PR DESCRIPTION
Calling hass.config_entries.async_forward_entry_setup is deprecated and will be removed in Home Assistant 2025.6


https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/